### PR TITLE
Fix journal cursor tests

### DIFF
--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -55,7 +55,7 @@ fn ts() {
     }
 
     let mut j = journal::OpenOptions::default().open().unwrap();
-    log!(log::Level::Info, "rust-systemd test_seek entry");
+    log!(log::Level::Info, "rust-systemd ts entry");
     j.seek(journal::JournalSeek::Head).unwrap();
     j.next().unwrap();
     let _s = j.timestamp().unwrap();
@@ -81,13 +81,14 @@ fn test_seek() {
     let c1 = j.cursor().unwrap();
     let c2 = j.cursor().unwrap();
     assert_eq!(c1, c2);
+
     j.seek(journal::JournalSeek::Tail).unwrap();
-    j.next_entry().unwrap();
-    let c3 = j.cursor().unwrap();
-    let valid_cursor = journal::JournalSeek::Cursor { cursor: c3 };
+    assert!(j.next_entry().unwrap().is_none());
+
+    let valid_cursor = journal::JournalSeek::Cursor { cursor: c1 };
     j.seek(valid_cursor).unwrap();
     let invalid_cursor = journal::JournalSeek::Cursor {
-        cursor: "".to_string(),
+        cursor: "invalid".to_string(),
     };
     assert!(j.seek(invalid_cursor).is_err());
 }
@@ -107,8 +108,10 @@ fn test_simple_match() {
 
     // seek tail
     j.seek(journal::JournalSeek::Tail).unwrap();
-    journal::send(&[&filter, msg]);
+    j.previous().unwrap();
     j.match_add(key, value).unwrap();
+
+    journal::send(&[&filter, msg]);
     let mut waits = 0;
     loop {
         if j.next().unwrap() == 0 {
@@ -134,6 +137,7 @@ fn test_simple_match() {
 
     // check for negative matches
     j.seek(journal::JournalSeek::Tail).unwrap();
+    j.previous().unwrap();
     j.match_flush()
         .unwrap()
         .match_add("NOKEY", "NOVALUE")


### PR DESCRIPTION
In order to create a cursor, the journal must be at a valid entry. As the docs say:

    Note that sd_journal_get_cursor() will not work before
    sd_journal_next(3) (or related call) has been called at least
    once, in order to position the read pointer at a valid entry.

The existing tests do this, but at least on recent versions of systemd (255), it seems that calling sd_journal_next after a seek to tail does not meet this requirement. If the journal is at the tail, subsequent nexts will always stay a the abstract 'tail' position, not at a valid entry because the "next" call will never seek backwards. This causes cursor creation to fail.

A similar issue exists in the 'match' test. It seeks to tail and then attempts to 'next' in a loop, but this will always be 'tail', so it never sees the matching entry. In both cases, the fix is to 'previous' after the seek to tail.

Fixed by calling prev after the tail seek in these cases. I'm not positive that is the best approach (I'm not a libsystemd expert), but it seemed reasonable to me.