### PR TITLE
New function timestamp_usec

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -992,9 +992,14 @@ impl JournalRef {
 
     /// Returns timestamp at which current journal entry was recorded.
     pub fn timestamp(&self) -> Result<time::SystemTime> {
+        Ok(system_time_from_realtime_usec(self.timestamp_usec()?))
+    }
+
+    /// Returns timestamp at which current journal entry was recorded in u64 format.
+    pub fn timestamp_usec(&self) -> Result<u64> {
         let mut timestamp_us: u64 = 0;
         ffi_result(unsafe { ffi::sd_journal_get_realtime_usec(self.as_ptr(), &mut timestamp_us) })?;
-        Ok(system_time_from_realtime_usec(timestamp_us))
+        Ok(timestamp_us)
     }
 
     /// Returns monotonic timestamp and boot ID at which current journal entry was recorded.

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -70,6 +70,27 @@ fn ts() {
 }
 
 #[test]
+fn test_timestamp() {
+    if !have_journal() {
+        return;
+    }
+
+    let mut j = journal::OpenOptions::default().open().unwrap();
+    log!(log::Level::Info, "rust-systemd ts entry");
+    j.seek(journal::JournalSeek::Head).unwrap();
+    j.next().unwrap();
+    let timestamp_system_time = j.timestamp().unwrap();
+    let timestamp_usec = j.timestamp_usec().unwrap();
+
+    let since_the_epoch = timestamp_system_time
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("Time went backwards");
+    let timestamp_system_time_usec = since_the_epoch.as_micros() as u64;
+
+    assert_eq!(timestamp_usec, timestamp_system_time_usec);
+}
+
+#[test]
 fn test_seek() {
     let mut j = journal::OpenOptions::default().open().unwrap();
     if !have_journal() {


### PR DESCRIPTION
Hello,

This is a great crate, but I need a function that I want to share.

I created the function pub fn timestamp_usec(&self) -> Result<u64> on JournalRef struct. It the same than the timestamp, but it gives a direct access to the realtime_usec u64 value. 

I also made a test to ensure that both functions "timestamp_usec" and "timestamp" return the same.

Thank you

PS 
Without this function I can still get the u64 value with the help of workarounds ;)

