### PR TITLE
Add rust wrappers for systemd-logind session functions

### DIFF
--- a/examples/enumerate_sessions.rs
+++ b/examples/enumerate_sessions.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2025, Snap Inc.
+//
+// Example: Enumerate all systemd sessions and display their information
+//
+// This example demonstrates how to use the new session enumeration functions
+// to list all active sessions and their properties.
+
+extern crate systemd;
+
+use std::time::{Duration, UNIX_EPOCH};
+use systemd::login;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Enumerating systemd sessions...\n");
+
+    // Get all active sessions
+    let sessions = login::get_sessions()?;
+
+    if sessions.is_empty() {
+        println!("No active sessions found.");
+        return Ok(());
+    }
+
+    println!("Found {} session(s):\n", sessions.len());
+
+    for session_id in sessions {
+        println!("Session: {}", session_id);
+
+        // Get session UID
+        if let Ok(uid) = login::get_session_uid(&session_id) {
+            println!("  UID: {}", uid);
+        }
+
+        // Get session start time
+        if let Ok(start_time_usec) = login::get_session_start_time(&session_id) {
+            let start_time = UNIX_EPOCH + Duration::from_micros(start_time_usec);
+            println!("  Start time: {:?}", start_time);
+        }
+
+        // Get session TTY (if available)
+        if let Ok(Some(tty)) = login::get_session_tty(&session_id) {
+            println!("  TTY: {}", tty);
+        }
+
+        // Get session display (if available)
+        if let Ok(Some(display)) = login::get_session_display(&session_id) {
+            println!("  Display: {}", display);
+        }
+
+        // Get session type
+        if let Ok(Some(session_type)) = login::get_session_type(&session_id) {
+            println!("  Type: {}", session_type);
+        }
+
+        // Get remote host (if available)
+        if let Ok(Some(remote_host)) = login::get_session_remote_host(&session_id) {
+            println!("  Remote host: {}", remote_host);
+        }
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/libsystemd-sys/src/login.rs
+++ b/libsystemd-sys/src/login.rs
@@ -38,6 +38,7 @@ extern "C" {
     pub fn sd_session_is_remote(session: *const c_char) -> c_int;
     pub fn sd_session_get_state(session: *const c_char, state: *mut *mut c_char) -> c_int;
     pub fn sd_session_get_uid(session: *const c_char, uid: *mut uid_t) -> c_int;
+    pub fn sd_session_get_start_time(session: *const c_char, usec: *mut u64) -> c_int;
     pub fn sd_session_get_seat(session: *const c_char, seat: *mut *mut c_char) -> c_int;
     pub fn sd_session_get_service(session: *const c_char, service: *mut *mut c_char) -> c_int;
     pub fn sd_session_get_type(session: *const c_char, _type: *mut *mut c_char) -> c_int;

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,5 +1,5 @@
 use super::ffi::{c_char, c_uint, pid_t, uid_t};
-use super::{free_cstring, Result};
+use super::{free_cstring, Error, Result};
 use crate::ffi_result;
 use ::ffi::login as ffi;
 use cstr_argument::CStrArgument;
@@ -124,4 +124,133 @@ pub fn get_owner_uid(pid: Option<pid_t>) -> Result<uid_t> {
     let p: pid_t = pid.unwrap_or(0);
     ffi_result(unsafe { ffi::sd_pid_get_owner_uid(p, &mut c_owner_uid) })?;
     Ok(c_owner_uid as uid_t)
+}
+
+/// Retrieves a list of all active sessions.
+///
+/// Returns a vector of session identifiers for all currently active sessions
+/// in the system. This is useful for enumerating all sessions rather than
+/// querying individual sessions.
+pub fn get_sessions() -> Result<Vec<String>> {
+    let mut sessions_ptr: *mut *mut c_char = ptr::null_mut();
+    let n_sessions = ffi_result(unsafe { ffi::sd_get_sessions(&mut sessions_ptr) })?;
+
+    if n_sessions == 0 || sessions_ptr.is_null() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions = Vec::with_capacity(n_sessions as usize);
+
+    unsafe {
+        for i in 0..n_sessions {
+            let session_ptr = *sessions_ptr.offset(i as isize);
+            if !session_ptr.is_null() {
+                if let Some(session_id) = free_cstring(session_ptr) {
+                    sessions.push(session_id);
+                }
+            }
+        }
+
+        // Free the main array
+        ::libc::free(sessions_ptr as *mut ::libc::c_void);
+    }
+
+    Ok(sessions)
+}
+
+/// Retrieves the user ID (UID) of the specified session.
+pub fn get_session_uid<S: CStrArgument>(session: S) -> Result<uid_t> {
+    let session = session.into_cstr();
+    let mut uid: uid_t = 0;
+    ffi_result(unsafe { ffi::sd_session_get_uid(session.as_ref().as_ptr(), &mut uid) })?;
+    Ok(uid)
+}
+
+/// Retrieves the start time of the specified session as microseconds since Unix epoch.
+pub fn get_session_start_time<S: CStrArgument>(session: S) -> Result<u64> {
+    let session = session.into_cstr();
+    let mut start_time_usec: u64 = 0;
+    ffi_result(unsafe {
+        ffi::sd_session_get_start_time(session.as_ref().as_ptr(), &mut start_time_usec)
+    })?;
+    Ok(start_time_usec)
+}
+
+/// Retrieves the TTY device name of the specified session.
+///
+/// Returns the TTY device name (e.g., "tty1", "pts/0") for the session.
+/// Returns None if the session is not associated with a TTY.
+pub fn get_session_tty<S: CStrArgument>(session: S) -> Result<Option<String>> {
+    let session = session.into_cstr();
+    let mut tty_ptr: *mut c_char = ptr::null_mut();
+    let result = unsafe { ffi::sd_session_get_tty(session.as_ref().as_ptr(), &mut tty_ptr) };
+
+    if result < 0 {
+        if result == -libc::ENODATA {
+            return Ok(None); // Session has no TTY, this is not an error
+        }
+        return Err(Error::from_raw_os_error(-result));
+    }
+
+    Ok(unsafe { free_cstring(tty_ptr) })
+}
+
+/// Retrieves the remote host name of the specified session.
+///
+/// Returns the remote host name for sessions that were established from
+/// a remote location (e.g., SSH sessions). Returns None if the session
+/// is local or if no remote host information is available.
+pub fn get_session_remote_host<S: CStrArgument>(session: S) -> Result<Option<String>> {
+    let session = session.into_cstr();
+    let mut remote_host_ptr: *mut c_char = ptr::null_mut();
+    let result =
+        unsafe { ffi::sd_session_get_remote_host(session.as_ref().as_ptr(), &mut remote_host_ptr) };
+
+    if result < 0 {
+        if result == -libc::ENODATA {
+            return Ok(None); // No remote host, this is not an error
+        }
+        return Err(Error::from_raw_os_error(-result));
+    }
+
+    Ok(unsafe { free_cstring(remote_host_ptr) })
+}
+
+/// Retrieves the display name of the specified session.
+///
+/// Returns the display identifier (e.g., ":0") for graphical sessions.
+/// Returns None if the session is not graphical or has no display.
+pub fn get_session_display<S: CStrArgument>(session: S) -> Result<Option<String>> {
+    let session = session.into_cstr();
+    let mut display_ptr: *mut c_char = ptr::null_mut();
+    let result =
+        unsafe { ffi::sd_session_get_display(session.as_ref().as_ptr(), &mut display_ptr) };
+
+    if result < 0 {
+        if result == -libc::ENODATA {
+            return Ok(None); // No display, this is not an error
+        }
+        return Err(Error::from_raw_os_error(-result));
+    }
+
+    Ok(unsafe { free_cstring(display_ptr) })
+}
+
+/// Retrieves the session type of the specified session.
+///
+/// Returns the session type (e.g., "tty", "x11", "wayland", "mir") which
+/// indicates the type of session.
+pub fn get_session_type<S: CStrArgument>(session: S) -> Result<Option<String>> {
+    let session = session.into_cstr();
+    let mut type_ptr: *mut c_char = ptr::null_mut();
+    let result = unsafe { ffi::sd_session_get_type(session.as_ref().as_ptr(), &mut type_ptr) };
+
+    if result < 0 {
+        if result == -libc::ENODATA {
+            return Ok(None); // No type information, this is not an error
+        }
+        return Err(Error::from_raw_os_error(-result));
+    }
+
+    Ok(unsafe { free_cstring(type_ptr) })
 }

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -102,3 +102,108 @@ fn test_get_owner_uid() {
         // Nothing meaningful to check here
     }
 }
+
+#[test]
+fn test_get_sessions() {
+    let sessions = login::get_sessions();
+    let has_systemd = booted();
+    assert!(has_systemd.is_ok());
+    if has_systemd.unwrap() {
+        // Running under systemd - sessions should be retrievable
+        assert!(sessions.is_ok());
+        let session_list = sessions.unwrap();
+        // We can't assume any particular number of sessions, but the call should succeed
+        println!("Found {} sessions", session_list.len());
+    } else {
+        // Without systemd, this should fail gracefully
+        assert!(sessions.is_err());
+    }
+}
+
+#[test]
+fn test_session_functions() {
+    let has_systemd = booted();
+    assert!(has_systemd.is_ok());
+    if !has_systemd.unwrap() {
+        // Skip session-specific tests without systemd
+        return;
+    }
+
+    let sessions = login::get_sessions();
+    if sessions.is_err() {
+        // No sessions available, skip session-specific tests
+        return;
+    }
+
+    let session_list = sessions.unwrap();
+    if session_list.is_empty() {
+        // No sessions available, skip session-specific tests
+        return;
+    }
+
+    // Test session functions with the first available session
+    let session_id = &session_list[0];
+
+    // Test get_session_uid
+    let uid_result = login::get_session_uid(session_id);
+    // UID should be retrievable for any valid session
+    assert!(
+        uid_result.is_ok(),
+        "Failed to get UID for session {}: {:?}",
+        session_id,
+        uid_result
+    );
+
+    // Test get_session_start_time
+    let start_time_result = login::get_session_start_time(session_id);
+    // Start time should be retrievable for any valid session
+    assert!(
+        start_time_result.is_ok(),
+        "Failed to get start time for session {}: {:?}",
+        session_id,
+        start_time_result
+    );
+    let start_time = start_time_result.unwrap();
+    // Start time should be a reasonable timestamp (after year 2000)
+    assert!(
+        start_time > 946_684_800_000_000,
+        "Start time seems too early: {}",
+        start_time
+    );
+
+    // Test get_session_tty (may return None for non-TTY sessions)
+    let tty_result = login::get_session_tty(session_id);
+    assert!(
+        tty_result.is_ok(),
+        "Failed to get TTY for session {}: {:?}",
+        session_id,
+        tty_result
+    );
+
+    // Test get_session_remote_host (may return None for local sessions)
+    let remote_host_result = login::get_session_remote_host(session_id);
+    assert!(
+        remote_host_result.is_ok(),
+        "Failed to get remote host for session {}: {:?}",
+        session_id,
+        remote_host_result
+    );
+
+    // Test get_session_display (may return None for non-GUI sessions)
+    let display_result = login::get_session_display(session_id);
+    assert!(
+        display_result.is_ok(),
+        "Failed to get display for session {}: {:?}",
+        session_id,
+        display_result
+    );
+
+    // Test get_session_type (should return Some value for any session)
+    let type_result = login::get_session_type(session_id);
+    assert!(
+        type_result.is_ok(),
+        "Failed to get type for session {}: {:?}",
+        session_id,
+        type_result
+    );
+}


### PR DESCRIPTION
Add safe Rust wrappers for systemd-logind session enumeration functions that were previously only available through unsafe FFI. These functions enable applications to query systemd for information about active sessions without needing to implement unsafe memory management.

Added Functions:

- `login::get_sessions()` - Returns a list of all active session IDs
- `login::get_session_uid(session)` - Get the user ID of a session
- `login::get_session_start_time(session)` - Get session start time as microseconds since Unix epoch
- `login::get_session_tty(session)` - Get TTY device name (returns `Option<String>`)
- `login::get_session_remote_host(session)` - Get remote host for SSH sessions (returns `Option<String>`)
- `login::get_session_display(session)` - Get display for GUI sessions (returns `Option<String>`)
- `login::get_session_type(session)` - Get session type like "tty", "x11", "wayland" (returns `Option<String>`)